### PR TITLE
Avoid wildcard origins when credentials are allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# ChapelChat: AI Assistant for Churches
+# ChapelChat: AI Assistant for Small Businesses and Churches
 
-ChapelChat is a powerful, AI-driven chatbot designed to help churches and ministries engage with their communities. It provides instant, accurate answers to questions about church events, beliefs, and schedules, freeing up staff to focus on what matters most.
+ChapelChat is a Spring Boot application that delivers an AI-driven chatbot for organizations. It answers questions about events, products, or beliefs by combining a customizable knowledge base with OpenAI.
 
 ## Key Features
 
-- **AI-Powered Chatbot**: Leverages the OpenAI API to provide intelligent, context-aware responses.
-- **Church-Specific Knowledge**: Easily customizable with church-specific information, including service times, event details, and core beliefs.
-- **Secure and Scalable**: Built with Spring Boot and secured with API keys, ensuring reliable and safe operation.
-- **Extensible Architecture**: Designed for easy expansion, allowing new features and integrations to be added with minimal effort.
+- **AI-Powered Chatbot**: Uses OpenAI's API to generate context-aware responses.
+- **Customizable Knowledge Base**: Load business or church data such as service times, product lists, or beliefs.
+- **Secure and Scalable**: API key authentication and Dockerized services ensure reliable, safe operation.
+- **Extensible Architecture**: Modular design makes adding new integrations straightforward.
+- **Data Validation**: Node.js script validates organization profile JSON against a schema.
 
 ## Getting Started
 
@@ -15,69 +16,83 @@ ChapelChat is a powerful, AI-driven chatbot designed to help churches and minist
 
 - Java 21
 - Maven
-- PostgreSQL
+- Docker
 
-### Installation
+### Installation and Configuration
 
-1. **Clone the repository**:
+1. **Clone the repository**
 
    ```bash
    git clone https://github.com/your-username/ChapelChat.git
    ```
 
-2. **Configure the application**:
-
-   - Create a `application-local.yaml` file in `src/main/resources`.
-   - Add your PostgreSQL and OpenAI API key details:
-   
-        ```yaml
-
-     spring:
-       datasource:
-         url: jdbc:postgresql://localhost:5432/your-db
-         username: your-username
-         password: your-password
-     openai:
-       api:
-         key: your-openai-api-key
-     ```
-
-3. **Run the application**:
+2. **Start the database**
 
    ```bash
-   mvn spring-boot:run
+   docker-compose up -d
+   ```
 
+3. **Configure the application**
+
+   Create `src/main/resources/application-local.yaml`:
+
+   ```yaml
+   spring:
+     datasource:
+       url: jdbc:postgresql://localhost:5432/chapelchat
+       username: chapel
+       password: chapel
+   openai:
+     api:
+       key: your-openai-api-key
+   ```
+
+4. **Run the application**
+
+   ```bash
    mvn spring-boot:run -Dspring-boot.run.profiles=local
    ```
 
 ## Database
 
-The app runs on a Postgreql database. Liquibase is ran to version control changes.
-
-- Run the command below to clear checksums. The user name and password are for local use only.
+ChapelChat uses PostgreSQL with Liquibase for schema migrations. To clear Liquibase checksums:
 
 ```bash
 liquibase clearCheckSums --url=jdbc:postgresql://localhost:5432/chapelchat --username=chapel --password=chapel
-
 ```
 
 ## Project Structure
 
-ChapelChat follows a standard Spring Boot project structure:
+```text
+src/
+├── main/
+│   ├── java/com/erikmikac/ChapelChat
+│   │   ├── config/      # Security, API key, and web configs
+│   │   ├── controller/  # REST controllers
+│   │   ├── service/     # Business logic and OpenAI calls
+│   │   ├── entity/      # JPA entities
+│   │   └── repository/  # Spring Data repositories
+│   └── resources/
+│       ├── churches/    # Organization profiles
+│       └── db/changelog # Liquibase migrations
+└── test/java            # Unit and integration tests
+```
 
-- **`src/main/java`**: Contains the core application code.
-  - **`config`**: Houses configuration classes for security, API keys, and web settings.
-  - **`controller`**: Manages incoming web requests and routes them to the appropriate services.
-  - **`service`**: Implements the business logic, including AI integration and data management.
-  - **`entity`**: Defines the database schema and entities.
-  - **`repository`**: Provides an interface for database operations.
-- **`src/main/resources`**: Includes configuration files, database migrations, and static assets.
-  - **`churches`**: Stores church-specific profiles in JSON format.
-  - **`db/changelog`**: Contains Liquibase scripts for database schema management.
+## Data Validation
+
+Validate organization profile JSON files:
+
+```bash
+cd src/main/resources/churches
+npm install ajv
+node validate.js
+```
 
 ## Usage
 
-To ask a question, send a POST request to the `/ask` endpoint with your API key and query:
+Send a question to the `/ask` endpoint:
+
+> **Note:** This is an MVP. API keys are currently bundled directly into the frontend.
 
 ```bash
 curl -X POST http://localhost:8080/ask \
@@ -86,10 +101,11 @@ curl -X POST http://localhost:8080/ask \
      -d '{"question": "What time is the Sunday service?"}'
 ```
 
-## Contributing
-
-Contributions are welcome! Please fork the repository and submit a pull request with your changes.
-
 ## Scheduled Jobs
 
-- **ChatLogCleanupJob**: This job runs daily at 2:00 AM and deletes chat logs older than 90 days (configurable via the `chatlog.retention.days` property). This helps to keep the database clean and manage storage costs.
+- **ChatLogCleanupJob** – runs daily at 2:00 AM and deletes chat logs older than 90 days (configurable via `chatlog.retention.days`).
+
+## Contributing
+
+Contributions are welcome! Fork the repository and open a pull request.
+

--- a/src/main/java/com/erikmikac/ChapelChat/config/CorsConfig.java
+++ b/src/main/java/com/erikmikac/ChapelChat/config/CorsConfig.java
@@ -42,6 +42,9 @@ public class CorsConfig {
 
                 // Future dashboard API (JWT / cookies)
                 registry.addMapping("/api/**")
+                        // Explicit origins are required when credentials are allowed
+                        // to avoid Spring's wildcard + credentials restriction
+                        .allowedOrigins("http://localhost", "https://yourdashboard.tld")
                         .allowedOriginPatterns("http://localhost:*", "https://*.yourdashboard.tld")
                         .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                         .allowedHeaders("Content-Type", "Accept", "Authorization")

--- a/src/test/java/com/erikmikac/ChapelChat/controller/AskControllerTest.java
+++ b/src/test/java/com/erikmikac/ChapelChat/controller/AskControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +31,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import jakarta.servlet.http.HttpServletRequest;
 
 @WebMvcTest(controllers = AskController.class, excludeAutoConfiguration = {org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration.class})
+@Import(TestMvcConfig.class)
 public class AskControllerTest {
 
     @Autowired MockMvc mockMvc;

--- a/src/test/java/com/erikmikac/ChapelChat/controller/TestMvcConfig.java
+++ b/src/test/java/com/erikmikac/ChapelChat/controller/TestMvcConfig.java
@@ -1,0 +1,24 @@
+package com.erikmikac.ChapelChat.controller;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@TestConfiguration
+public class TestMvcConfig {
+
+    @Bean
+    public WebMvcConfigurer testCorsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOriginPatterns("http://localhost:*")
+                        .allowedMethods("*")
+                        .allowedHeaders("*")
+                        .allowCredentials(false);
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Configure AskController tests with explicit CORS rules
- Add test CORS configuration to avoid wildcard origins with credentials
- Expand README with detailed setup, project structure, and validation steps

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f861d600832baeab1635e47d1608